### PR TITLE
add tripResult as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.0.xx - xx.xx.2025
+- enforce arrays for `OJPTripRefineDelivery.TripResult` nodes
+
 ## 0.0.14 - 20.08.2025
 - adds `ExpectedDepartureOccupancy` to TR response - [TR - add occupancy model #20](https://github.com/openTdataCH/ojp-shared-types/issues/20) - [PR #23](https://github.com/openTdataCH/ojp-shared-types/pull/23)
 

--- a/src/types/openapi-dependencies.ts
+++ b/src/types/openapi-dependencies.ts
@@ -132,6 +132,9 @@ const MapArrayTags: Record<string, boolean> = {
   'tripInfoResult.previousCall': true,
   'tripInfoResult.onwardCall': true,
   'journeyTrack.trackSection': true,
+
+  // TripRefineResult
+  'OJPTripRefineDelivery.tripResult': true,
 };
 
 // TODO - this should be generated


### PR DESCRIPTION
Refine Responses can return a single trip, which does not match the schema definition, `tripResult` needs to always be an array