### PR TITLE
Updates OJP 1.0 RailSubMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.12 - 16.06.2026
+- use `RailSubmodeEnum`, `ModeStructure`, `ModeFilterStructure` for OJP 1.0
+- adds `guaranteedConnection` to `TransferTypeEnum`
+
 ## 0.1.11 - 24.04.2026
 - Updates npm publish - [PR #50](https://github.com/openTdataCH/ojp-shared-types/pull/50)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Notes
 - include the `ojp-shared-types` package in the `./package.json` dependencies of the project 
 ```
   "dependencies": {
-    "ojp-shared-types": "0.1.11"
+    "ojp-shared-types": "0.1.12"
   }
 ```
 

--- a/openapi/legacy/ojp-v1/ojp-lir-request.yml
+++ b/openapi/legacy/ojp-v1/ojp-lir-request.yml
@@ -39,7 +39,7 @@ components:
           xml:
             name: Type
         modes:
-          $ref: "../../ojp-shared.yml#/components/schemas/ModeFilterStructure"
+          $ref: "./ojp-shared.yml#/components/schemas/ModeFilterStructure"
           xml:
             name: Modes
         pointOfInterestFilter:

--- a/openapi/legacy/ojp-v1/ojp-shared.yml
+++ b/openapi/legacy/ojp-v1/ojp-shared.yml
@@ -358,6 +358,16 @@ components:
           xml:
             name: OperatorName
 
+    # OJP 2.0 https://vdvde.github.io/OJP/develop/documentation-tables/siri.html#type_siri__RailSubmodesOfTransportEnumeration
+    # OJP 1.0 https://laidig.github.io/siri-20-java/doc/schemas/siri_modes-v1_1_xsd/elements/RailSubmode.html
+    RailSubmodeEnum:
+      type: string 
+      enum: [highSpeedRailService, longDistanceTrain, interRegionalRailService, carTransportRailService, sleeperRailService, regionalRail, railShuttle, suburbanRailway, unknown]
+      xml:
+        name: RailSubmode
+        namespace: "http://www.siri.org.uk/siri"
+        prefix: siri
+
     # modified from 'openapi/ojp-shared.yml#/components/schemas/DatedJourney'
     # https://vdvde.github.io/OJP/develop/documentation-tables/ojp.html#type_ojp__DatedJourneyStructure
     DatedJourney:

--- a/openapi/legacy/ojp-v1/ojp-shared.yml
+++ b/openapi/legacy/ojp-v1/ojp-shared.yml
@@ -368,6 +368,163 @@ components:
         namespace: "http://www.siri.org.uk/siri"
         prefix: siri
 
+    # https://vdvde.github.io/OJP/develop/documentation-tables/ojp.html#type_ojp__ModeStructure
+    # adapted for OJP 1.0 - i.e. railSubmode
+    ModeStructure:
+      type: object
+      xml:
+        name: Mode
+      required:
+        - ptMode
+      properties:
+        ptMode:
+          $ref: '../../ojp-shared.yml#/components/schemas/VehicleModesOfTransportEnum'
+          xml:
+            name: PtMode
+        airSubmode:
+          type: string
+          xml:
+            name: AirSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        busSubmode:
+          type: string
+          xml:
+            name: BusSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        coachSubmode:
+          type: string
+          xml:
+            name: CoachSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        funicularSubmode:
+          type: string
+          xml:
+            name: FunicularSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        metroSubmode:
+          type: string
+          xml:
+            name: MetroSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        tramSubmode:
+          type: string
+          xml:
+            name: TramSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        telecabinSubmode:
+          type: string
+          xml:
+            name: TelecabinSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        railSubmode:
+          $ref: "#/components/schemas/RailSubmodeEnum"
+          xml:
+            name: RailSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        waterSubmode:
+          type: string
+          xml:
+            name: WaterSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        name:
+          $ref: '../../ojp-shared.yml#/components/schemas/InternationalText'
+          xml:
+            name: Name
+        shortName:
+          $ref: '../../ojp-shared.yml#/components/schemas/InternationalText'
+          xml:
+            name: ShortName
+
+    # https://vdvde.github.io/OJP/develop/documentation-tables/ojp.html#type_ojp__ModeFilterStructure
+    # adapted for OJP 1.0 - i.e. railSubmode
+    ModeFilterStructure:
+      type: object
+      xml:
+        name: ModeFilter
+      required:
+        - ptMode
+        - personalMode
+      properties:
+        exclude:
+          type: boolean
+          xml:
+            name: Exclude
+        ptMode:
+          type: array
+          xml:
+            name: PtMode
+          items:
+            $ref: '../../ojp-shared.yml#/components/schemas/VehicleModesOfTransportEnum'
+        personalMode:
+          type: array
+          xml:
+            name: PersonalMode
+          items:
+            $ref: '../../ojp-shared.yml#/components/schemas/PersonalModesEnumeration'
+        airSubmode:
+          type: string
+          xml:
+            name: AirSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        busSubmode:
+          type: string
+          xml:
+            name: BusSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        coachSubmode:
+          type: string
+          xml:
+            name: CoachSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        funicularSubmode:
+          type: string
+          xml:
+            name: FunicularSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        metroSubmode:
+          type: string
+          xml:
+            name: MetroSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        tramSubmode:
+          type: string
+          xml:
+            name: TramSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        telecabinSubmode:
+          type: string
+          xml:
+            name: telecabinSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        railSubmode:
+          $ref: "#/components/schemas/RailSubmodeEnum"
+          xml:
+            name: RailSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+        waterSubmode:
+          type: string
+          xml:
+            name: WaterSubmode
+            namespace: "http://www.siri.org.uk/siri"
+            prefix: siri
+
     # modified from 'openapi/ojp-shared.yml#/components/schemas/DatedJourney'
     # https://vdvde.github.io/OJP/develop/documentation-tables/ojp.html#type_ojp__DatedJourneyStructure
     DatedJourney:

--- a/openapi/legacy/ojp-v1/ojp-shared.yml
+++ b/openapi/legacy/ojp-v1/ojp-shared.yml
@@ -568,7 +568,7 @@ components:
             namespace: "http://www.siri.org.uk/siri"
             prefix: siri
         mode:
-          $ref: '../../ojp-shared.yml#/components/schemas/ModeStructure'
+          $ref: '#/components/schemas/ModeStructure'
           xml:
             name: Mode
         productCategory:
@@ -668,7 +668,7 @@ components:
           xml:
             name: Mode
           items:
-            $ref: '../../ojp-shared.yml#/components/schemas/ModeStructure'
+            $ref: '#/components/schemas/ModeStructure'
         attribute:
           type: array
           xml:

--- a/openapi/legacy/ojp-v1/ojp-tr-request.yml
+++ b/openapi/legacy/ojp-v1/ojp-tr-request.yml
@@ -35,7 +35,7 @@ components:
           xml:
             name: PtModeFilter
           items:
-            $ref: "../../ojp-shared.yml#/components/schemas/ModeFilterStructure"
+            $ref: "./ojp-shared.yml#/components/schemas/ModeFilterStructure"
         walkSpeed:
           type: number
           xml:

--- a/openapi/ojp-shared.yml
+++ b/openapi/ojp-shared.yml
@@ -60,7 +60,7 @@ components:
     # https://vdvde.github.io/OJP/develop/documentation-tables/ojp.html#type_ojp__TransferTypeEnumeration
     TransferTypeEnum:
       type: string
-      enum: [walk, remainInVehicle, changeWithinVehicle]
+      enum: [walk, remainInVehicle, changeWithinVehicle, guaranteedConnection]
       xml:
         name: TransferType
     

--- a/openapi/ojp-shared.yml
+++ b/openapi/ojp-shared.yml
@@ -325,8 +325,8 @@ components:
       xml:
         name: StopPoint
       required:
-        - stopPointRef
-        - stopPointName
+        - stopPlaceRef
+        - stopPlaceName
       properties:
         stopPlaceRef:
           type: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-shared-types",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Shared types for OJP models based on OpenAPI / XSD Schema",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.1.11';
+export const VERSION = '0.1.12';

--- a/src/types/generated/legacy/ojp-v1/ojp-fare-request.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-fare-request.ts
@@ -178,7 +178,7 @@ export interface paths {
                                                                 tramSubmode?: string;
                                                                 telecabinSubmode?: string;
                                                                 /** @enum {string} */
-                                                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                                 waterSubmode?: string;
                                                                 name?: {
                                                                     text: string;
@@ -638,7 +638,7 @@ export interface components {
                                 tramSubmode?: string;
                                 telecabinSubmode?: string;
                                 /** @enum {string} */
-                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                 waterSubmode?: string;
                                 name?: {
                                     text: string;
@@ -1094,7 +1094,7 @@ export interface components {
                                     tramSubmode?: string;
                                     telecabinSubmode?: string;
                                     /** @enum {string} */
-                                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                     waterSubmode?: string;
                                     name?: {
                                         text: string;
@@ -1533,7 +1533,7 @@ export interface components {
                                         tramSubmode?: string;
                                         telecabinSubmode?: string;
                                         /** @enum {string} */
-                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                         waterSubmode?: string;
                                         name?: {
                                             text: string;
@@ -1980,7 +1980,7 @@ export interface components {
                                                 tramSubmode?: string;
                                                 telecabinSubmode?: string;
                                                 /** @enum {string} */
-                                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                 waterSubmode?: string;
                                                 name?: {
                                                     text: string;

--- a/src/types/generated/legacy/ojp-v1/ojp-lir-request.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-lir-request.ts
@@ -82,7 +82,7 @@ export interface paths {
                                                 tramSubmode?: string;
                                                 telecabinSubmode?: string;
                                                 /** @enum {string} */
-                                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                 waterSubmode?: string;
                                             };
                                             pointOfInterestFilter?: {
@@ -137,7 +137,7 @@ export interface components {
                 tramSubmode?: string;
                 telecabinSubmode?: string;
                 /** @enum {string} */
-                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                 waterSubmode?: string;
             };
             pointOfInterestFilter?: {
@@ -210,7 +210,7 @@ export interface components {
                     tramSubmode?: string;
                     telecabinSubmode?: string;
                     /** @enum {string} */
-                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                     waterSubmode?: string;
                 };
                 pointOfInterestFilter?: {
@@ -277,7 +277,7 @@ export interface components {
                                 tramSubmode?: string;
                                 telecabinSubmode?: string;
                                 /** @enum {string} */
-                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                 waterSubmode?: string;
                             };
                             pointOfInterestFilter?: {

--- a/src/types/generated/legacy/ojp-v1/ojp-lir-response.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-lir-response.ts
@@ -58,8 +58,8 @@ export interface paths {
                                                     };
                                                 };
                                                 stopPlace?: {
-                                                    stopPlaceRef?: string;
-                                                    stopPlaceName?: {
+                                                    stopPlaceRef: string;
+                                                    stopPlaceName: {
                                                         text: string;
                                                     };
                                                 };
@@ -116,7 +116,7 @@ export interface paths {
                                                     tramSubmode?: string;
                                                     telecabinSubmode?: string;
                                                     /** @enum {string} */
-                                                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                     waterSubmode?: string;
                                                     name?: {
                                                         text: string;
@@ -183,8 +183,8 @@ export interface components {
                     };
                 };
                 stopPlace?: {
-                    stopPlaceRef?: string;
-                    stopPlaceName?: {
+                    stopPlaceRef: string;
+                    stopPlaceName: {
                         text: string;
                     };
                 };
@@ -241,7 +241,7 @@ export interface components {
                     tramSubmode?: string;
                     telecabinSubmode?: string;
                     /** @enum {string} */
-                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                     waterSubmode?: string;
                     name?: {
                         text: string;
@@ -288,8 +288,8 @@ export interface components {
                         };
                     };
                     stopPlace?: {
-                        stopPlaceRef?: string;
-                        stopPlaceName?: {
+                        stopPlaceRef: string;
+                        stopPlaceName: {
                             text: string;
                         };
                     };
@@ -346,7 +346,7 @@ export interface components {
                         tramSubmode?: string;
                         telecabinSubmode?: string;
                         /** @enum {string} */
-                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                         waterSubmode?: string;
                         name?: {
                             text: string;
@@ -399,8 +399,8 @@ export interface components {
                                     };
                                 };
                                 stopPlace?: {
-                                    stopPlaceRef?: string;
-                                    stopPlaceName?: {
+                                    stopPlaceRef: string;
+                                    stopPlaceName: {
                                         text: string;
                                     };
                                 };
@@ -457,7 +457,7 @@ export interface components {
                                     tramSubmode?: string;
                                     telecabinSubmode?: string;
                                     /** @enum {string} */
-                                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                     waterSubmode?: string;
                                     name?: {
                                         text: string;

--- a/src/types/generated/legacy/ojp-v1/ojp-ser-response.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-ser-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -117,7 +117,7 @@ export interface paths {
                                                         tramSubmode?: string;
                                                         telecabinSubmode?: string;
                                                         /** @enum {string} */
-                                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                         waterSubmode?: string;
                                                         name?: {
                                                             text: string;
@@ -308,7 +308,7 @@ export interface paths {
                                                         tramSubmode?: string;
                                                         telecabinSubmode?: string;
                                                         /** @enum {string} */
-                                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                         waterSubmode?: string;
                                                         name?: {
                                                             text: string;
@@ -524,7 +524,7 @@ export interface components {
                     tramSubmode?: string;
                     telecabinSubmode?: string;
                     /** @enum {string} */
-                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                     waterSubmode?: string;
                     name?: {
                         text: string;
@@ -716,7 +716,7 @@ export interface components {
                         tramSubmode?: string;
                         telecabinSubmode?: string;
                         /** @enum {string} */
-                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                         waterSubmode?: string;
                         name?: {
                             text: string;
@@ -799,8 +799,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -857,7 +857,7 @@ export interface components {
                             tramSubmode?: string;
                             telecabinSubmode?: string;
                             /** @enum {string} */
-                            railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                             waterSubmode?: string;
                             name?: {
                                 text: string;
@@ -1048,7 +1048,7 @@ export interface components {
                             tramSubmode?: string;
                             telecabinSubmode?: string;
                             /** @enum {string} */
-                            railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                             waterSubmode?: string;
                             name?: {
                                 text: string;
@@ -1137,8 +1137,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };
@@ -1195,7 +1195,7 @@ export interface components {
                                         tramSubmode?: string;
                                         telecabinSubmode?: string;
                                         /** @enum {string} */
-                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                         waterSubmode?: string;
                                         name?: {
                                             text: string;
@@ -1386,7 +1386,7 @@ export interface components {
                                         tramSubmode?: string;
                                         telecabinSubmode?: string;
                                         /** @enum {string} */
-                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                         waterSubmode?: string;
                                         name?: {
                                             text: string;

--- a/src/types/generated/legacy/ojp-v1/ojp-shared.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-shared.ts
@@ -93,8 +93,8 @@ export interface components {
                         };
                     };
                     stopPlace?: {
-                        stopPlaceRef?: string;
-                        stopPlaceName?: {
+                        stopPlaceRef: string;
+                        stopPlaceName: {
                             text: string;
                         };
                     };
@@ -151,7 +151,7 @@ export interface components {
                         tramSubmode?: string;
                         telecabinSubmode?: string;
                         /** @enum {string} */
-                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                         waterSubmode?: string;
                         name?: {
                             text: string;
@@ -221,6 +221,43 @@ export interface components {
                 text: string;
             };
         };
+        /** @enum {string} */
+        RailSubmodeEnum: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
+        ModeStructure: {
+            /** @enum {string} */
+            ptMode: "air" | "bus" | "coach" | "trolleyBus" | "metro" | "rail" | "tram" | "water" | "ferry" | "cableway" | "funicular" | "lift" | "telecabin" | "other" | "unknown";
+            airSubmode?: string;
+            busSubmode?: string;
+            coachSubmode?: string;
+            funicularSubmode?: string;
+            metroSubmode?: string;
+            tramSubmode?: string;
+            telecabinSubmode?: string;
+            /** @enum {string} */
+            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
+            waterSubmode?: string;
+            name?: {
+                text: string;
+            };
+            shortName?: {
+                text: string;
+            };
+        };
+        ModeFilterStructure: {
+            exclude?: boolean;
+            ptMode: ("air" | "bus" | "coach" | "trolleyBus" | "metro" | "rail" | "tram" | "water" | "ferry" | "cableway" | "funicular" | "lift" | "telecabin" | "other" | "unknown")[];
+            personalMode: ("foot" | "bicycle" | "car" | "motorcycle" | "truck" | "scooter" | "other")[];
+            airSubmode?: string;
+            busSubmode?: string;
+            coachSubmode?: string;
+            funicularSubmode?: string;
+            metroSubmode?: string;
+            tramSubmode?: string;
+            telecabinSubmode?: string;
+            /** @enum {string} */
+            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
+            waterSubmode?: string;
+        };
         DatedJourney: {
             conventionalModeOfOperation?: string;
             operatingDayRef: string;
@@ -239,7 +276,7 @@ export interface components {
                 tramSubmode?: string;
                 telecabinSubmode?: string;
                 /** @enum {string} */
-                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                 waterSubmode?: string;
                 name?: {
                     text: string;
@@ -297,8 +334,8 @@ export interface components {
                 };
             };
             stopPlace?: {
-                stopPlaceRef?: string;
-                stopPlaceName?: {
+                stopPlaceRef: string;
+                stopPlaceName: {
                     text: string;
                 };
             };
@@ -355,7 +392,7 @@ export interface components {
                 tramSubmode?: string;
                 telecabinSubmode?: string;
                 /** @enum {string} */
-                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                 waterSubmode?: string;
                 name?: {
                     text: string;

--- a/src/types/generated/legacy/ojp-v1/ojp-tir-response.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-tir-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -117,7 +117,7 @@ export interface paths {
                                                         tramSubmode?: string;
                                                         telecabinSubmode?: string;
                                                         /** @enum {string} */
-                                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                         waterSubmode?: string;
                                                         name?: {
                                                             text: string;
@@ -265,7 +265,7 @@ export interface paths {
                                                     tramSubmode?: string;
                                                     telecabinSubmode?: string;
                                                     /** @enum {string} */
-                                                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                     waterSubmode?: string;
                                                     name?: {
                                                         text: string;
@@ -469,7 +469,7 @@ export interface components {
                     tramSubmode?: string;
                     telecabinSubmode?: string;
                     /** @enum {string} */
-                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                     waterSubmode?: string;
                     name?: {
                         text: string;
@@ -581,8 +581,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -639,7 +639,7 @@ export interface components {
                             tramSubmode?: string;
                             telecabinSubmode?: string;
                             /** @enum {string} */
-                            railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                             waterSubmode?: string;
                             name?: {
                                 text: string;
@@ -787,7 +787,7 @@ export interface components {
                         tramSubmode?: string;
                         telecabinSubmode?: string;
                         /** @enum {string} */
-                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                         waterSubmode?: string;
                         name?: {
                             text: string;
@@ -905,8 +905,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };
@@ -963,7 +963,7 @@ export interface components {
                                         tramSubmode?: string;
                                         telecabinSubmode?: string;
                                         /** @enum {string} */
-                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                         waterSubmode?: string;
                                         name?: {
                                             text: string;
@@ -1111,7 +1111,7 @@ export interface components {
                                     tramSubmode?: string;
                                     telecabinSubmode?: string;
                                     /** @enum {string} */
-                                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                     waterSubmode?: string;
                                     name?: {
                                         text: string;

--- a/src/types/generated/legacy/ojp-v1/ojp-tr-request.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-tr-request.ts
@@ -111,7 +111,7 @@ export interface paths {
                                                 tramSubmode?: string;
                                                 telecabinSubmode?: string;
                                                 /** @enum {string} */
-                                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                 waterSubmode?: string;
                                             }[];
                                             walkSpeed?: number;
@@ -180,7 +180,7 @@ export interface components {
                 tramSubmode?: string;
                 telecabinSubmode?: string;
                 /** @enum {string} */
-                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                 waterSubmode?: string;
             }[];
             walkSpeed?: number;
@@ -296,7 +296,7 @@ export interface components {
                     tramSubmode?: string;
                     telecabinSubmode?: string;
                     /** @enum {string} */
-                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                     waterSubmode?: string;
                 }[];
                 walkSpeed?: number;
@@ -407,7 +407,7 @@ export interface components {
                                 tramSubmode?: string;
                                 telecabinSubmode?: string;
                                 /** @enum {string} */
-                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                 waterSubmode?: string;
                             }[];
                             walkSpeed?: number;

--- a/src/types/generated/legacy/ojp-v1/ojp-tr-response.ts
+++ b/src/types/generated/legacy/ojp-v1/ojp-tr-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -117,7 +117,7 @@ export interface paths {
                                                         tramSubmode?: string;
                                                         telecabinSubmode?: string;
                                                         /** @enum {string} */
-                                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                         waterSubmode?: string;
                                                         name?: {
                                                             text: string;
@@ -313,7 +313,7 @@ export interface paths {
                                                                 tramSubmode?: string;
                                                                 telecabinSubmode?: string;
                                                                 /** @enum {string} */
-                                                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                                 waterSubmode?: string;
                                                                 name?: {
                                                                     text: string;
@@ -832,7 +832,7 @@ export interface components {
                     tramSubmode?: string;
                     telecabinSubmode?: string;
                     /** @enum {string} */
-                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                     waterSubmode?: string;
                     name?: {
                         text: string;
@@ -1238,7 +1238,7 @@ export interface components {
                         tramSubmode?: string;
                         telecabinSubmode?: string;
                         /** @enum {string} */
-                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                         waterSubmode?: string;
                         name?: {
                             text: string;
@@ -1653,7 +1653,7 @@ export interface components {
                             tramSubmode?: string;
                             telecabinSubmode?: string;
                             /** @enum {string} */
-                            railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                             waterSubmode?: string;
                             name?: {
                                 text: string;
@@ -2071,7 +2071,7 @@ export interface components {
                                 tramSubmode?: string;
                                 telecabinSubmode?: string;
                                 /** @enum {string} */
-                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                 waterSubmode?: string;
                                 name?: {
                                     text: string;
@@ -2375,8 +2375,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -2433,7 +2433,7 @@ export interface components {
                             tramSubmode?: string;
                             telecabinSubmode?: string;
                             /** @enum {string} */
-                            railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                            railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                             waterSubmode?: string;
                             name?: {
                                 text: string;
@@ -2629,7 +2629,7 @@ export interface components {
                                     tramSubmode?: string;
                                     telecabinSubmode?: string;
                                     /** @enum {string} */
-                                    railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                    railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                     waterSubmode?: string;
                                     name?: {
                                         text: string;
@@ -2939,8 +2939,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };
@@ -2997,7 +2997,7 @@ export interface components {
                                         tramSubmode?: string;
                                         telecabinSubmode?: string;
                                         /** @enum {string} */
-                                        railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                        railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                         waterSubmode?: string;
                                         name?: {
                                             text: string;
@@ -3193,7 +3193,7 @@ export interface components {
                                                 tramSubmode?: string;
                                                 telecabinSubmode?: string;
                                                 /** @enum {string} */
-                                                railSubmode?: "international" | "highSpeedRail" | "interregionalRail" | "railShuttle" | "local" | "vehicleTunnelTransportRailService";
+                                                railSubmode?: "highSpeedRailService" | "longDistanceTrain" | "interRegionalRailService" | "carTransportRailService" | "sleeperRailService" | "regionalRail" | "railShuttle" | "suburbanRailway" | "unknown";
                                                 waterSubmode?: string;
                                                 name?: {
                                                     text: string;

--- a/src/types/generated/ojp-lir-response.ts
+++ b/src/types/generated/ojp-lir-response.ts
@@ -58,8 +58,8 @@ export interface paths {
                                                     };
                                                 };
                                                 stopPlace?: {
-                                                    stopPlaceRef?: string;
-                                                    stopPlaceName?: {
+                                                    stopPlaceRef: string;
+                                                    stopPlaceName: {
                                                         text: string;
                                                     };
                                                 };
@@ -184,8 +184,8 @@ export interface components {
                     };
                 };
                 stopPlace?: {
-                    stopPlaceRef?: string;
-                    stopPlaceName?: {
+                    stopPlaceRef: string;
+                    stopPlaceName: {
                         text: string;
                     };
                 };
@@ -290,8 +290,8 @@ export interface components {
                         };
                     };
                     stopPlace?: {
-                        stopPlaceRef?: string;
-                        stopPlaceName?: {
+                        stopPlaceRef: string;
+                        stopPlaceName: {
                             text: string;
                         };
                     };
@@ -402,8 +402,8 @@ export interface components {
                                     };
                                 };
                                 stopPlace?: {
-                                    stopPlaceRef?: string;
-                                    stopPlaceName?: {
+                                    stopPlaceRef: string;
+                                    stopPlaceName: {
                                         text: string;
                                     };
                                 };

--- a/src/types/generated/ojp-ser-response.ts
+++ b/src/types/generated/ojp-ser-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -807,8 +807,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -1165,8 +1165,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };

--- a/src/types/generated/ojp-shared.ts
+++ b/src/types/generated/ojp-shared.ts
@@ -22,7 +22,7 @@ export interface components {
         /** @enum {string} */
         PerspectiveEnum: "general" | "stopPoint" | "vehicleJourney";
         /** @enum {string} */
-        TransferTypeEnum: "walk" | "remainInVehicle" | "changeWithinVehicle";
+        TransferTypeEnum: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
         /** @enum {string} */
         FareClassEnum: "unknown" | "firstClass" | "secondClass";
         /** @enum {string} */
@@ -120,8 +120,8 @@ export interface components {
             };
         };
         StopPlace: {
-            stopPlaceRef?: string;
-            stopPlaceName?: {
+            stopPlaceRef: string;
+            stopPlaceName: {
                 text: string;
             };
         };
@@ -205,8 +205,8 @@ export interface components {
                 };
             };
             stopPlace?: {
-                stopPlaceRef?: string;
-                stopPlaceName?: {
+                stopPlaceRef: string;
+                stopPlaceName: {
                     text: string;
                 };
             };
@@ -628,8 +628,8 @@ export interface components {
                         };
                     };
                     stopPlace?: {
-                        stopPlaceRef?: string;
-                        stopPlaceName?: {
+                        stopPlaceRef: string;
+                        stopPlaceName: {
                             text: string;
                         };
                     };

--- a/src/types/generated/ojp-tir-response.ts
+++ b/src/types/generated/ojp-tir-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -595,8 +595,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -939,8 +939,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };

--- a/src/types/generated/ojp-tr-response.ts
+++ b/src/types/generated/ojp-tr-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -426,7 +426,7 @@ export interface paths {
                                                     };
                                                     transferLeg?: {
                                                         /** @enum {string} */
-                                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                                                         legStart: {
                                                             stopPointRef?: string;
                                                             stopPlaceRef?: string;
@@ -1071,7 +1071,7 @@ export interface components {
         };
         TransferLeg: {
             /** @enum {string} */
-            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
             legStart: {
                 stopPointRef?: string;
                 stopPlaceRef?: string;
@@ -1490,7 +1490,7 @@ export interface components {
             };
             transferLeg?: {
                 /** @enum {string} */
-                transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                 legStart: {
                     stopPointRef?: string;
                     stopPlaceRef?: string;
@@ -1922,7 +1922,7 @@ export interface components {
                 };
                 transferLeg?: {
                     /** @enum {string} */
-                    transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                    transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                     legStart: {
                         stopPointRef?: string;
                         stopPlaceRef?: string;
@@ -2362,7 +2362,7 @@ export interface components {
                     };
                     transferLeg?: {
                         /** @enum {string} */
-                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                         legStart: {
                             stopPointRef?: string;
                             stopPlaceRef?: string;
@@ -2601,8 +2601,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -2968,7 +2968,7 @@ export interface components {
                         };
                         transferLeg?: {
                             /** @enum {string} */
-                            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                             legStart: {
                                 stopPointRef?: string;
                                 stopPlaceRef?: string;
@@ -3213,8 +3213,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };
@@ -3580,7 +3580,7 @@ export interface components {
                                     };
                                     transferLeg?: {
                                         /** @enum {string} */
-                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                                         legStart: {
                                             stopPointRef?: string;
                                             stopPlaceRef?: string;

--- a/src/types/generated/ojp-trr-request.ts
+++ b/src/types/generated/ojp-trr-request.ts
@@ -275,7 +275,7 @@ export interface paths {
                                                     };
                                                     transferLeg?: {
                                                         /** @enum {string} */
-                                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                                                         legStart: {
                                                             stopPointRef?: string;
                                                             stopPlaceRef?: string;
@@ -761,7 +761,7 @@ export interface components {
                         };
                         transferLeg?: {
                             /** @enum {string} */
-                            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                             legStart: {
                                 stopPointRef?: string;
                                 stopPlaceRef?: string;
@@ -1222,7 +1222,7 @@ export interface components {
                                     };
                                     transferLeg?: {
                                         /** @enum {string} */
-                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                                         legStart: {
                                             stopPointRef?: string;
                                             stopPlaceRef?: string;

--- a/src/types/generated/ojp-trr-response.ts
+++ b/src/types/generated/ojp-trr-response.ts
@@ -59,8 +59,8 @@ export interface paths {
                                                         };
                                                     };
                                                     stopPlace?: {
-                                                        stopPlaceRef?: string;
-                                                        stopPlaceName?: {
+                                                        stopPlaceRef: string;
+                                                        stopPlaceName: {
                                                             text: string;
                                                         };
                                                     };
@@ -426,7 +426,7 @@ export interface paths {
                                                     };
                                                     transferLeg?: {
                                                         /** @enum {string} */
-                                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                                                         legStart: {
                                                             stopPointRef?: string;
                                                             stopPlaceRef?: string;
@@ -690,8 +690,8 @@ export interface components {
                             };
                         };
                         stopPlace?: {
-                            stopPlaceRef?: string;
-                            stopPlaceName?: {
+                            stopPlaceRef: string;
+                            stopPlaceName: {
                                 text: string;
                             };
                         };
@@ -1057,7 +1057,7 @@ export interface components {
                         };
                         transferLeg?: {
                             /** @enum {string} */
-                            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                            transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                             legStart: {
                                 stopPointRef?: string;
                                 stopPlaceRef?: string;
@@ -1302,8 +1302,8 @@ export interface components {
                                         };
                                     };
                                     stopPlace?: {
-                                        stopPlaceRef?: string;
-                                        stopPlaceName?: {
+                                        stopPlaceRef: string;
+                                        stopPlaceName: {
                                             text: string;
                                         };
                                     };
@@ -1669,7 +1669,7 @@ export interface components {
                                     };
                                     transferLeg?: {
                                         /** @enum {string} */
-                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle";
+                                        transferType: "walk" | "remainInVehicle" | "changeWithinVehicle" | "guaranteedConnection";
                                         legStart: {
                                             stopPointRef?: string;
                                             stopPlaceRef?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,8 @@ export type OccupancyLevelEnum = sharedComponents["schemas"]["OccupancyLevelEnum
 export type RailSubmodeEnum = sharedComponents["schemas"]["RailSubmodeEnum"];
 export type OptimisationMethodEnum = sharedComponents["schemas"]["OptimisationMethodEnum"];
 
+export type OJPv1_RailSubmodeEnum = ojpV1_SharedComponents["schemas"]["RailSubmodeEnum"];
+
 export type GeoPositionSchema = sharedComponents["schemas"]["GeoPosition"];
 export type PlaceRefSchema = sharedComponents["schemas"]["PlaceRef"];
 export type InternationalTextSchema = sharedComponents["schemas"]["InternationalText"];
@@ -71,6 +73,8 @@ export type ModeStructureSchema = sharedComponents['schemas']['ModeStructure'];
 export type ProductCategorySchema = sharedComponents['schemas']['ProductCategory'];
 export type GeneralAttributeSchema = sharedComponents['schemas']['GeneralAttribute'];
 export type ModeFilterSchema = sharedComponents["schemas"]['ModeFilterStructure'];
+export type OJPv1_ModeStructureSchema = ojpV1_SharedComponents['schemas']['ModeStructure'];
+export type OJPv1_ModeFilterSchema = ojpV1_SharedComponents['schemas']['ModeFilterStructure'];
 
 export type TrackSectionSchema = sharedComponents['schemas']['TrackSectionStructure'];
 export type OJPv1_TrackSectionSchema = ojpV1_SharedComponents['schemas']['TrackSectionStructure'];
@@ -117,6 +121,7 @@ export type InitialInputSchema = locationInformationRequestComponents['schemas']
 export type LIR_RequestParamsSchema = locationInformationRequestComponents['schemas']['PlaceParam'];
 export type LocationInformationRequestOJP = locationInformationRequestComponents['schemas']['OJP'];
 export type LocationInformationRequestSchema = locationInformationRequestComponents['schemas']['OJPLocationInformationRequest'];
+export type OJPv1_LIR_RequestParamsSchema = ojpV1_LocationInformationRequestComponents['schemas']['PlaceParam'];
 
 export type PlaceResultSchema = locationInformationResponseComponents['schemas']['PlaceResult'];
 export type LocationInformationRequestResponseOJP = locationInformationResponseComponents['schemas']['OJP'];


### PR DESCRIPTION
- use `RailSubmodeEnum`, `ModeStructure`, `ModeFilterStructure` for OJP 1.0
- adds `guaranteedConnection` to `TransferTypeEnum`